### PR TITLE
Refactor pipeline for muDM-only inference

### DIFF
--- a/main.py
+++ b/main.py
@@ -31,7 +31,7 @@ def main() -> None:
         logM_sps_obs,
         nsteps=nsteps,
         nwalkers=20,
-        initial_guess=np.array([12.6, 0.2]),
+        initial_guess=np.array([12.6]),
         backend_file="chains_bless_new_test_aaa.h5",
         parallel=True,
         nproc=mp.cpu_count() - 3,
@@ -43,7 +43,7 @@ def main() -> None:
 
     # 转为 DataFrame 并加上列名
     # param_names = ["param1", "param2", "param3", "param4", "param5"]  # 你可以改成实际参数名
-    param_names = [r"$\mu_{DM}$", r"$\alpha$"]
+    param_names = [r"$\mu_{DM}$"]
 
     df_samples = pd.DataFrame(samples, columns=param_names)
 
@@ -57,7 +57,7 @@ def main() -> None:
     # )
 
     # 真值
-    true_values = [12.91, 0.1]
+    true_values = [12.91]
 
     # 绘制 pairplot
     g = sns.pairplot(

--- a/run_mcmc.py
+++ b/run_mcmc.py
@@ -44,8 +44,8 @@ def run_mcmc(
     nwalkers, nsteps:
         MCMC configuration.
     initial_guess:
-        Initial position of the walkers in parameter space.  Must have length 2
-        corresponding to ``(muDM, alpha)``.
+        Initial position of the walkers in parameter space.  Must have length 1
+        corresponding to ``muDM``.
     backend_file:
         Filename or path for the HDF5 backend.  If a relative path is
         supplied, the file will be placed inside the ``chains`` directory.  The
@@ -83,9 +83,9 @@ def run_mcmc(
     # return sampler
 
 
-    ndim = 2
+    ndim = 1
     if initial_guess is None:
-        initial_guess = np.array([12.5, 0.1])
+        initial_guess = np.array([12.5])
 
     # === 使用 pathlib 构建路径 ===
     base_dir = Path(__file__).parent.resolve()


### PR DESCRIPTION
## Summary
- fix alpha offset to 0.4 and adjust likelihood to depend solely on muDM
- simplify MCMC wrapper and main script for single-parameter sampling

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689738954f18832d9b12518ce6d2014f